### PR TITLE
Extend find all tasks filters

### DIFF
--- a/src/main/java/os/failsafe/executor/FailsafeExecutor.java
+++ b/src/main/java/os/failsafe/executor/FailsafeExecutor.java
@@ -465,6 +465,49 @@ public class FailsafeExecutor {
     }
 
     /**
+     * Returns all tasks matching the criteria. A null value as parameter means not constraining the result.
+     * <p>
+     * If no sort order is specified then result set is ordered by CREATED_DATE DESC, ID DESC.
+     *
+     * @param taskName          finds the tasks by constraining the taskName
+     * @param parameter         finds the tasks by constraining the parameter
+     * @param failed            finds the tasks by constraining if they are failed or not failed.
+     * @param errorMessage      finds the tasks by constraining the error message contains text (case-insensitive)
+     * @param createdDateFrom   finds the tasks by constraining from created date (exclusive).
+     * @param createdDateTo     finds the tasks by constraining to created date (exclusive).
+     * @param failureDateFrom   finds the tasks by constraining from failure date (exclusive).
+     * @param failureDateTo     finds the tasks by constraining to failure date (exclusive).
+     * @param offset            offset to start from
+     * @param limit             limit of the result set
+     * @param sorts             sort order of the result set. See {@link Sort} for available sort criteria.
+     * @return                  list of all persisted tasks
+     */
+    public List<Task> findAll(String taskName,
+                              String parameter,
+                              Boolean failed,
+                              String errorMessage,
+                              LocalDateTime createdDateFrom,
+                              LocalDateTime createdDateTo,
+                              LocalDateTime failureDateFrom,
+                              LocalDateTime failureDateTo,
+                              int offset,
+                              int limit,
+                              Sort... sorts) {
+        return taskRepository.findAll(
+                taskName,
+                parameter,
+                failed,
+                errorMessage,
+                createdDateFrom,
+                createdDateTo,
+                failureDateFrom,
+                failureDateTo,
+                offset,
+                limit,
+                sorts);
+    }
+
+    /**
      * Returns a single task.
      *
      * @param taskId the id of the task

--- a/src/main/java/os/failsafe/executor/FailsafeExecutor.java
+++ b/src/main/java/os/failsafe/executor/FailsafeExecutor.java
@@ -473,10 +473,10 @@ public class FailsafeExecutor {
      * @param parameter         finds the tasks by constraining the parameter
      * @param failed            finds the tasks by constraining if they are failed or not failed.
      * @param errorMessage      finds the tasks by constraining the error message contains text (case-insensitive)
-     * @param createdDateFrom   finds the tasks by constraining from created date (exclusive).
-     * @param createdDateTo     finds the tasks by constraining to created date (exclusive).
-     * @param failureDateFrom   finds the tasks by constraining from failure date (exclusive).
-     * @param failureDateTo     finds the tasks by constraining to failure date (exclusive).
+     * @param createdDateFromInclusive   finds the tasks by constraining from created date (inclusive).
+     * @param createdDateToExclusive     finds the tasks by constraining to created date (exclusive).
+     * @param failureDateFromInclusive   finds the tasks by constraining from failure date (inclusive).
+     * @param failureDateToExclusive     finds the tasks by constraining to failure date (exclusive).
      * @param offset            offset to start from
      * @param limit             limit of the result set
      * @param sorts             sort order of the result set. See {@link Sort} for available sort criteria.
@@ -486,10 +486,10 @@ public class FailsafeExecutor {
                               String parameter,
                               Boolean failed,
                               String errorMessage,
-                              LocalDateTime createdDateFrom,
-                              LocalDateTime createdDateTo,
-                              LocalDateTime failureDateFrom,
-                              LocalDateTime failureDateTo,
+                              LocalDateTime createdDateFromInclusive,
+                              LocalDateTime createdDateToExclusive,
+                              LocalDateTime failureDateFromInclusive,
+                              LocalDateTime failureDateToExclusive,
                               int offset,
                               int limit,
                               Sort... sorts) {
@@ -498,10 +498,10 @@ public class FailsafeExecutor {
                 parameter,
                 failed,
                 errorMessage,
-                createdDateFrom,
-                createdDateTo,
-                failureDateFrom,
-                failureDateTo,
+                createdDateFromInclusive,
+                createdDateToExclusive,
+                failureDateFromInclusive,
+                failureDateToExclusive,
                 offset,
                 limit,
                 sorts);

--- a/src/main/java/os/failsafe/executor/TaskRepository.java
+++ b/src/main/java/os/failsafe/executor/TaskRepository.java
@@ -16,7 +16,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -224,8 +223,8 @@ class TaskRepository {
     }
 
 
-    public List<Task> findAll(String taskName, String parameter, Boolean failed, String errorMessage, LocalDateTime createdDateFrom, LocalDateTime createdDateTo,
-                              LocalDateTime failureDateFrom, LocalDateTime failureDateTo, int offset, int limit, Sort[] sorts) {
+    public List<Task> findAll(String taskName, String parameter, Boolean failed, String errorMessage, LocalDateTime createdDateFromInclusive, LocalDateTime createdDateToExclusive,
+                              LocalDateTime failureDateFromInclusive, LocalDateTime failureDateToExclusive, int offset, int limit, Sort[] sorts) {
         if (offset < 0) {
             throw new IllegalArgumentException("Offset must be greater or equal 0");
         }
@@ -242,10 +241,10 @@ class TaskRepository {
                 .where(taskName, "NAME")
                 .where(parameter, "PARAMETER")
                 .isNullOrNotNull(failed, "FAIL_TIME")
-                .gt(getTimeString(createdDateFrom), "CREATED_DATE")
-                .lt(getTimeString(createdDateTo), "CREATED_DATE")
-                .gt(getTimeString(failureDateFrom), "FAIL_TIME")
-                .lt(getTimeString(failureDateTo), "FAIL_TIME")
+                .gte(createdDateFromInclusive, "CREATED_DATE")
+                .lt(createdDateToExclusive, "CREATED_DATE")
+                .gte(failureDateFromInclusive, "FAIL_TIME")
+                .lt(failureDateToExclusive, "FAIL_TIME")
                 .containsIgnoreCase(errorMessage, "EXCEPTION_MESSAGE")
                 .orderBy(sorts)
                 .limit(offset, limit)
@@ -415,11 +414,5 @@ class TaskRepository {
         String stackTrace = StringUtils.fromReader(rs.getCharacterStream("STACK_TRACE"));
 
         return new ExecutionFailure(failTime.toLocalDateTime(), exceptionMessage, stackTrace);
-    }
-
-    private static String getTimeString(LocalDateTime time) {
-        return Optional.ofNullable(time)
-                .map(LocalDateTime::toString)
-                .orElse(null);
     }
 }

--- a/src/main/java/os/failsafe/executor/utils/WhereBuilder.java
+++ b/src/main/java/os/failsafe/executor/utils/WhereBuilder.java
@@ -33,6 +33,54 @@ public class WhereBuilder {
         return this;
     }
 
+    public WhereBuilder gt(String value, String field) {
+        if (StringUtils.isBlank(value)) {
+            return this;
+        }
+
+        if (sb.length() > 0) {
+            sb.append(" AND ");
+        } else {
+            sb.append(" WHERE ");
+        }
+
+        sb.append(String.format("(%s > ?)", field));
+        params.add(value);
+        return this;
+    }
+
+    public WhereBuilder lt(String value, String field) {
+        if (StringUtils.isBlank(value)) {
+            return this;
+        }
+
+        if (sb.length() > 0) {
+            sb.append(" AND ");
+        } else {
+            sb.append(" WHERE ");
+        }
+
+        sb.append(String.format("(%s < ?)", field));
+        params.add(value);
+        return this;
+    }
+
+    public WhereBuilder containsIgnoreCase(String value, String field) {
+        if (StringUtils.isBlank(value)) {
+            return this;
+        }
+
+        if (sb.length() > 0) {
+            sb.append(" AND ");
+        } else {
+            sb.append(" WHERE ");
+        }
+
+        sb.append(String.format("(LOWER(%s) LIKE ?)", field.toLowerCase()));
+        params.add(value);
+        return this;
+    }
+
     public WhereBuilder isNullOrNotNull(Boolean notNull, String field) {
         if (notNull == null) {
             return this;

--- a/src/main/java/os/failsafe/executor/utils/WhereBuilder.java
+++ b/src/main/java/os/failsafe/executor/utils/WhereBuilder.java
@@ -2,9 +2,9 @@ package os.failsafe.executor.utils;
 
 import os.failsafe.executor.Sort;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.sql.*;
+import java.time.*;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class WhereBuilder {
@@ -33,8 +33,10 @@ public class WhereBuilder {
         return this;
     }
 
-    public WhereBuilder gt(String value, String field) {
-        if (StringUtils.isBlank(value)) {
+    public WhereBuilder gte(LocalDateTime value, String field) {
+        Optional<Timestamp> date = mapToTimestamp(value);
+
+        if (!date.isPresent()) {
             return this;
         }
 
@@ -44,13 +46,15 @@ public class WhereBuilder {
             sb.append(" WHERE ");
         }
 
-        sb.append(String.format("(%s > ?)", field));
-        params.add(value);
+        sb.append(String.format("(%s >= ?)", field));
+        params.add(date.get());
         return this;
     }
 
-    public WhereBuilder lt(String value, String field) {
-        if (StringUtils.isBlank(value)) {
+    public WhereBuilder lt(LocalDateTime value, String field) {
+        Optional<Timestamp> date = mapToTimestamp(value);
+
+        if (!date.isPresent()) {
             return this;
         }
 
@@ -61,7 +65,7 @@ public class WhereBuilder {
         }
 
         sb.append(String.format("(%s < ?)", field));
-        params.add(value);
+        params.add(date.get());
         return this;
     }
 
@@ -132,5 +136,10 @@ public class WhereBuilder {
             this.where = where;
             this.params = params;
         }
+    }
+
+    private static Optional<Timestamp> mapToTimestamp(LocalDateTime time) {
+        return Optional.ofNullable(time)
+                .map(Timestamp::valueOf);
     }
 }

--- a/src/test/java/os/failsafe/executor/FailsafeExecutorShould.java
+++ b/src/test/java/os/failsafe/executor/FailsafeExecutorShould.java
@@ -189,6 +189,57 @@ class FailsafeExecutorShould {
     }
 
     @Test
+    void find_not_failed_task_by_more_filters() {
+        String taskIdNotFailed = failsafeExecutor.execute(TASK_NAME, parameter);
+        assertTrue(failsafeExecutor.findOne(taskIdNotFailed).isPresent());
+
+        List<Task> all = failsafeExecutor.findAll();
+        assertEquals(1, all.size());
+
+        LocalDateTime from = LocalDateTime.now().minusMinutes(1);
+        LocalDateTime dateTo = LocalDateTime.now().plusMinutes(1);
+        assertEquals(1, failsafeExecutor.findAll(null, null, null, null, from, dateTo, null, null, 0, 10).size());
+        assertEquals(1, failsafeExecutor.findAll(TASK_NAME, null, null, null, from, dateTo, null, null, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, from, dateTo, from, null, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, from, dateTo, null, dateTo, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, true, null, from, dateTo, null, null, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, from, dateTo, from, dateTo, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, "ERROR MESSAGE", null, null, null, null, 0, 10).size());
+
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, LocalDateTime.now().plusMinutes(1), null, null, null, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, null, null, LocalDateTime.now().plusMinutes(1), null, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, null, null, LocalDateTime.now().plusMinutes(1), null, 0, 10).size());
+    }
+
+    @Test
+    void find_failed_task_by_more_filters() throws Exception {
+        executionShouldFail = true;
+        failsafeExecutor.start();
+        awaitAllTasks(failsafeExecutor, () -> failsafeExecutor.execute(TASK_NAME, parameter), failures -> {
+            assertEquals(1, failures.size());
+            assertEquals(TASK_NAME, failures.get(0).getName());
+            assertEquals(parameter, failures.get(0).getParameter());
+        });
+
+        List<Task> all = failsafeExecutor.findAll();
+        assertEquals(1, all.size());
+
+        LocalDateTime from = LocalDateTime.now().minusMinutes(1);
+        LocalDateTime dateTo = LocalDateTime.now().plusMinutes(1);
+        assertEquals(1, failsafeExecutor.findAll(null, null, null, null, from, dateTo, null, null, 0, 10).size());
+        assertEquals(1, failsafeExecutor.findAll(TASK_NAME, null, null, null, from, dateTo, null, null, 0, 10).size());
+        assertEquals(1, failsafeExecutor.findAll(null, null, null, null, from, dateTo, from, null, 0, 10).size());
+        assertEquals(1, failsafeExecutor.findAll(null, null, null, null, from, dateTo, null, dateTo, 0, 10).size());
+        assertEquals(1, failsafeExecutor.findAll(null, null, true, null, from, dateTo, null, null, 0, 10).size());
+        assertEquals(1, failsafeExecutor.findAll(null, null, null, null, from, dateTo, from, dateTo, 0, 10).size());
+        assertEquals(1, failsafeExecutor.findAll(null, null, null, "", null, null, null, null, 0, 10).size());
+
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, dateTo, null, null, null, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, null, null, dateTo, null, 0, 10).size());
+        assertEquals(0, failsafeExecutor.findAll(null, null, null, null, null, null, dateTo, null, 0, 10).size());
+    }
+
+    @Test
     void execute_a_task() {
         String taskId = failsafeExecutor.execute(TASK_NAME, parameter);
 


### PR DESCRIPTION
Goal of this MR is allowing the following filters:

- Parameter Id - text input
- 
- Failure date-time from / to
- 
- Created date-time from / to
- 
- Task Name - text input
- 
- Error Message contains text case insensitive (text input)